### PR TITLE
Add Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+dist: trusty
+sudo: false
+
+language: cpp
+
+script:
+  - ./test-by-spec.sh


### PR DESCRIPTION
Прямо сейчас тест падает, но падает именно там, где должен.

Чтобы тестирование продолжало работать за пределами сего пуллреквеста, надо Виктору подключить репо gritzko/swarmcpp ко Трэвису.